### PR TITLE
Adding additional CWEs to Excessive Agency

### DIFF
--- a/CVE_CWE.md
+++ b/CVE_CWE.md
@@ -37,6 +37,10 @@ This document maps the [OWASP Top 10 for Large Language Model Applications](http
 
 ## LLM08: Excessive Agency
 
+- **[CWE-250](https://cwe.mitre.org/data/definitions/250.html)**: Execution with Unnecessary Privileges
+- **[CWE-266](https://cwe.mitre.org/data/definitions/266.html)**: Incorrect Privilege Assignment
+- **[CWE-274](https://cwe.mitre.org/data/definitions/274.html)**: Improper Handling of Insufficient Privileges
+- **[CWE-648](https://cwe.mitre.org/data/definitions/648.html)**: Incorrect Use of Privileged APIs
 - **[CWE-807](https://cwe.mitre.org/data/definitions/807.html)**: Reliance on Untrusted Inputs in a Security Decision
 - No direct CVE mapping available.
 


### PR DESCRIPTION
This pull request includes updates to the `CVE_CWE.md` file, specifically adding new CWE references under the section for LLM08: Excessive Agency.

Updates to CWE references:

* Added **[CWE-250](https://cwe.mitre.org/data/definitions/250.html)**: Execution with Unnecessary Privileges.
* Added **[CWE-266](https://cwe.mitre.org/data/definitions/266.html)**: Incorrect Privilege Assignment.
* Added **[CWE-274](https://cwe.mitre.org/data/definitions/274.html)**: Improper Handling of Insufficient Privileges.
* Added **[CWE-648](https://cwe.mitre.org/data/definitions/648.html)**: Incorrect Use of Privileged APIs. 